### PR TITLE
Add <=python3.7 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,6 @@ pyrender
 colorama
 coloredlogs
 aido-protocols-daffy
+
+# Allow compatibility with Python versions < 3.8
+typing_extensions

--- a/src/duckietown_world/world_duckietown/old_map_format.py
+++ b/src/duckietown_world/world_duckietown/old_map_format.py
@@ -1,4 +1,11 @@
-from typing import Dict, List, NewType, TypedDict, Union
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import TypedDict
+
+from typing import Dict, List, NewType, Union
 
 __all__ = ["MapFormat1", "MapFormat1Object", "MapFormat1Constants"]
 


### PR DESCRIPTION
Adds compatibility for Python versions which don't have `TypedDict` in the standard library via `typing` module. Currently this assumption causes `duckietown-world` to not be compatible with Colab or other environments which require Python 3.7.

This is the documented method for dealing with version differences with mypy, see [docs](https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=import#python-version-and-system-platform-checks).

Fixes https://github.com/duckietown/duckietown-world/issues/46
